### PR TITLE
Make czifui a peer dependency

### DIFF
--- a/.changeset/chilly-forks-talk.md
+++ b/.changeset/chilly-forks-talk.md
@@ -4,4 +4,4 @@
 "@czb-ui/core": patch
 ---
 
-czifui is now a peer dependency, update all package.jsons in apps, core library
+czifui is now a peer dependency, update all package.jsons in apps, core library. For the test-app add a czifui button to make sure czifui is being imported correctly. Both apps now have at least one czifui component.

--- a/.changeset/chilly-forks-talk.md
+++ b/.changeset/chilly-forks-talk.md
@@ -1,0 +1,7 @@
+---
+"storybook": patch
+"test-app": patch
+"@czb-ui/core": patch
+---
+
+czifui is now a peer dependency, update all package.jsons in apps, core library

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -12,12 +12,12 @@
     "@emotion/css": "^11.9.0",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
-    "@mui/base": "^5.0.0-alpha.89",
+    "@mui/base": "^5.0.0-alpha.90",
     "@mui/icons-material": "^5.8.4",
-    "@mui/lab": "^5.0.0-alpha.90",
-    "@mui/material": "^5.9.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "@mui/lab": "^5.0.0-alpha.91",
+    "@mui/material": "^5.9.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.4.18",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -16,6 +16,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.91",
     "@mui/material": "^5.9.1",
+    "czifui": "5.0.0-beta.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/lab": "^5.0.0-alpha.91",
     "@mui/material": "^5.9.1",
+    "czifui": "5.0.0-beta.6",
     "next": "12.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -11,14 +11,18 @@
   "dependencies": {
     "@czb-ui/biohub-logos": "*",
     "@czb-ui/core": "*",
+    "@emotion/css": "^11.9.0",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@fontsource/barlow": "^4.5.7",
     "@fontsource/lato": "^4.5.8",
-    "@mui/material": "^5.8.6",
+    "@mui/base": "^5.0.0-alpha.90",
+    "@mui/icons-material": "^5.8.4",
+    "@mui/lab": "^5.0.0-alpha.91",
+    "@mui/material": "^5.9.1",
     "next": "12.2.0",
-    "react": "18.0.0",
-    "react-dom": "18.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "eslint": "8.18.0",

--- a/apps/test-app/pages/index.js
+++ b/apps/test-app/pages/index.js
@@ -1,6 +1,7 @@
 import { GenericBanner } from "@czb-ui/core";
 import { Box } from "@mui/material";
 import Image from "next/image";
+import { Button } from "czifui";
 import viralBackgroundBiohub from "../public/images/viral_background_biohub.png";
 
 export default function Home() {
@@ -19,6 +20,9 @@ export default function Home() {
           />
         }
       />
+      <Button sdsStyle="rounded" sdsType="primary">
+        test
+      </Button>
     </Box>
   );
 }

--- a/packages/biohub-logos/README.md
+++ b/packages/biohub-logos/README.md
@@ -1,6 +1,6 @@
 # CZ Biohub Logos
 
-...as React Components.
+...as Material UI React Components.
 
 ## Installation
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ High level components for CZ Biohub. Based on [CZI's Science Design System](http
 ## Installation
 
 ```
-npm install @czb-ui/core @mui/material @emotion/react @emotion/styled
+npm install @czb-ui/core czifui @emotion/css @emotion/react @emotion/styled @mui/base @mui/material @mui/icons-material @mui/lab
 ```
 
 Additionally, install the needed fonts:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,8 @@
     "rollup": "^2.70.2",
     "rollup-plugin-delete": "^2.0.0",
     "tsconfig": "*",
-    "typescript": "^4.5.3"
+    "typescript": "^4.5.3",
+    "czifui": "5.0.0-beta.6"
   },
   "peerDependencies": {
     "@emotion/css": "^11.9.0",
@@ -29,10 +30,10 @@
     "@mui/material": "^5.6.1",
     "@mui/lab": "^5.0.0-alpha.91",
     "react": "^17.0.1 || ^18.0.0",
-    "react-dom": "^17.0.1 || ^18.0.0"
+    "react-dom": "^17.0.1 || ^18.0.0",
+    "czifui": "5.0.0-beta.6"
   },
   "dependencies": {
-    "czifui": "5.0.0-beta.6",
     "hamburger-react": "^2.5.0",
     "uuid": "^8.3.2"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,7 @@
     "@mui/base": "^5.0.0-alpha.83",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.6.1",
+    "@mui/lab": "^5.0.0-alpha.91",
     "react": "^17.0.1 || ^18.0.0",
     "react-dom": "^17.0.1 || ^18.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,29 +9,37 @@
     "dev": "rollup --config rollup.config.ts --watch"
   },
   "devDependencies": {
-    "@mui/material": "^5.8.6",
+    "@emotion/css": "^11.9.0",
+    "@emotion/react": "^11.9.3",
+    "@emotion/styled": "^11.9.3",
+    "@mui/base": "^5.0.0-alpha.90",
+    "@mui/icons-material": "^5.8.4",
+    "@mui/lab": "^5.0.0-alpha.91",
+    "@mui/material": "^5.9.1",
     "@rollup/plugin-typescript": "^8.3.2",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",
     "@types/uuid": "^8.3.4",
     "config": "*",
+    "czifui": "5.0.0-beta.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "rollup": "^2.70.2",
     "rollup-plugin-delete": "^2.0.0",
     "tsconfig": "*",
-    "typescript": "^4.5.3",
-    "czifui": "5.0.0-beta.6"
+    "typescript": "^4.5.3"
   },
   "peerDependencies": {
     "@emotion/css": "^11.9.0",
-    "@emotion/react": "^11.9.0",
-    "@emotion/styled": "^11.8.1",
-    "@mui/base": "^5.0.0-alpha.83",
+    "@emotion/react": "^11.9.3",
+    "@emotion/styled": "^11.9.3",
+    "@mui/base": "^5.0.0-alpha.90",
     "@mui/icons-material": "^5.8.4",
-    "@mui/material": "^5.6.1",
     "@mui/lab": "^5.0.0-alpha.91",
+    "@mui/material": "^5.9.1",
+    "czifui": "5.0.0-beta.6",
     "react": "^17.0.1 || ^18.0.0",
-    "react-dom": "^17.0.1 || ^18.0.0",
-    "czifui": "5.0.0-beta.6"
+    "react-dom": "^17.0.1 || ^18.0.0"
   },
   "dependencies": {
     "hamburger-react": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,15 +1950,15 @@
     prop-types "^15.8.1"
     react-is "^17.0.2"
 
-"@mui/base@5.0.0-alpha.89", "@mui/base@^5.0.0-alpha.89":
-  version "5.0.0-alpha.89"
-  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.89.tgz#d72681fa20e05297b426e113c47a0912b59c8b44"
-  integrity sha512-2g18hzt947qQ3gQQPOPEBfzQmaT2wafVhyJ7ZOZXeU6kKb88MdlHoPkK2lKXCHMBtRGnnsiF36j0rmhQXu0I5g==
+"@mui/base@5.0.0-alpha.90", "@mui/base@^5.0.0-alpha.90":
+  version "5.0.0-alpha.90"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.90.tgz#73700ba74e5c75096ee5d0bfe3ba4a3b3b81beef"
+  integrity sha512-hNKwzr+RkiuGsGrakz8Q2i5ezr4Dz4b4Qsdipt9SiMrhuFAra/i501VSaEIzwec9LC4G+vtW4fE7yJBB0XaAYw==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@emotion/is-prop-valid" "^1.1.3"
     "@mui/types" "^7.1.4"
-    "@mui/utils" "^5.9.0"
+    "@mui/utils" "^5.9.1"
     "@popperjs/core" "^2.11.5"
     clsx "^1.2.1"
     prop-types "^15.8.1"
@@ -1971,15 +1971,15 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@mui/lab@^5.0.0-alpha.90":
-  version "5.0.0-alpha.90"
-  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.90.tgz#c70549f2c398a5c5e41755de22c1e18c9e470d77"
-  integrity sha512-9ze3cIo5OU7XSdB/FaV6JHJlFfyg2MpedakDHcFncoZRL2vvKJas3NOBaLKKxNN360RdUiUbHJZzKcCOyhQJug==
+"@mui/lab@^5.0.0-alpha.91":
+  version "5.0.0-alpha.91"
+  resolved "https://registry.yarnpkg.com/@mui/lab/-/lab-5.0.0-alpha.91.tgz#7884d5d921425f4717d1ddadb1749aada5d64165"
+  integrity sha512-46qnSPlK39hz5rtMjxHIkCeRzU+7/I27AyEI5mxtCCr2q4r4nC6IV2+2BhyM/FU09+v9tV5rByLZTkEmjy3dQQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@mui/base" "5.0.0-alpha.89"
-    "@mui/system" "^5.9.0"
-    "@mui/utils" "^5.9.0"
+    "@mui/base" "5.0.0-alpha.90"
+    "@mui/system" "^5.9.1"
+    "@mui/utils" "^5.9.1"
     clsx "^1.2.1"
     prop-types "^15.8.1"
     react-is "^18.2.0"
@@ -2001,16 +2001,16 @@
     react-is "^17.0.2"
     react-transition-group "^4.4.2"
 
-"@mui/material@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.9.0.tgz#e1cc4f67f16d337e9b94939caa8d6905db45d4e4"
-  integrity sha512-KZN3QEeCtwSP1IRpDZ7KQghDX7tyxZojADRCn+UKnoq8HUGNMJm2XKdb7hy9/ybaSW4EXQSKXSGg1AjdfS7Cdg==
+"@mui/material@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.9.1.tgz#92990e6d4035792430dcf548b91db6f335aebdd3"
+  integrity sha512-c09SbaMm7Rl7Df9JRkXwPWNbnfrutmHERTJC46OJ9OMAM9+HGQihIbGln1k2Xj65jb3E+G498FZFAoSrrBDvwQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@mui/base" "5.0.0-alpha.89"
-    "@mui/system" "^5.9.0"
+    "@mui/base" "5.0.0-alpha.90"
+    "@mui/system" "^5.9.1"
     "@mui/types" "^7.1.4"
-    "@mui/utils" "^5.9.0"
+    "@mui/utils" "^5.9.1"
     "@types/react-transition-group" "^4.4.5"
     clsx "^1.2.1"
     csstype "^3.1.0"
@@ -2027,13 +2027,13 @@
     "@mui/utils" "^5.8.6"
     prop-types "^15.8.1"
 
-"@mui/private-theming@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.9.0.tgz#d2437ed95ecfa3bfc9d2ee7c6053c94d4931cb26"
-  integrity sha512-t0ZsWxE/LvX5RH5azjx1esBHbIfD9zjnbSAYkpE59BPpkOrqAYDGoJguL2EPd9LaUb6COmBozmAwNenvI6RJRQ==
+"@mui/private-theming@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.9.1.tgz#4f714ed9ebd587373dc77b3fc69e9f3e720f0190"
+  integrity sha512-eIh2IZJInNTdgPLMo9cruzm8UDX5amBBxxsSoNre7lRj3wcsu3TG5OKjIbzkf4VxHHEhdPeNNQyt92k7L78u2A==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@mui/utils" "^5.9.0"
+    "@mui/utils" "^5.9.1"
     prop-types "^15.8.1"
 
 "@mui/styled-engine@^5.8.0":
@@ -2069,16 +2069,16 @@
     csstype "^3.1.0"
     prop-types "^15.8.1"
 
-"@mui/system@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.9.0.tgz#804055bc6fcd557479b8b28dfca7ed5c98fd9bf9"
-  integrity sha512-KLZDYMmT1usokEJH+raGTh1SbdOx4BVrT+wg8nRpKGNii2sfc3ntuJSKuv3Fu9oeC9xVFTnNBHXKrpJuxeDcqg==
+"@mui/system@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.9.1.tgz#dadd1094b1582781cc524b112a0a126f60b23c25"
+  integrity sha512-ZixTmc2+sYp++avoYJ38eM70nfwwudN06vYCU4kfwa4nQPiH+bhLYZnfYkcXRKiDR/hfT0dptbOOfQGZqBYczQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@mui/private-theming" "^5.9.0"
+    "@mui/private-theming" "^5.9.1"
     "@mui/styled-engine" "^5.8.7"
     "@mui/types" "^7.1.4"
-    "@mui/utils" "^5.9.0"
+    "@mui/utils" "^5.9.1"
     clsx "^1.2.1"
     csstype "^3.1.0"
     prop-types "^15.8.1"
@@ -2099,10 +2099,10 @@
     prop-types "^15.8.1"
     react-is "^17.0.2"
 
-"@mui/utils@^5.9.0":
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.9.0.tgz#2e1ac58905b767de47412cb32475862875b8e880"
-  integrity sha512-GAaiWP6zBC3RE1NHP9y1c1iKZh5s/nyKKqWxfTrw5lNQY5tWTh9/47F682FuiE5WT1o3h4w/LEkSSIZpMEDzrA==
+"@mui/utils@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.9.1.tgz#2b2c9dadbf8ba6561e145b5688fb7df5ef15a934"
+  integrity sha512-8+4adOR3xusyJwvbnZxcjqcmbWvl7Og+260ZKIrSvwnFs0aLubL+8MhiceeDDGcmb0bTKxfUgRJ96j32Jb7P+A==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@types/prop-types" "^15.7.5"
@@ -10241,13 +10241,13 @@ react-docgen@^6.0.0-alpha.0:
     resolve "^1.17.0"
     strip-indent "^3.0.0"
 
-react-dom@18.0.0, react-dom@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz"
-  integrity sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.21.0"
+    scheduler "^0.23.0"
 
 react-element-to-jsx-string@^14.3.4:
   version "14.3.4"
@@ -10318,10 +10318,10 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@18.0.0, react@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.npmjs.org/react/-/react-18.0.0.tgz"
-  integrity sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -10775,10 +10775,10 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-scheduler@^0.21.0:
-  version "0.21.0"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz"
-  integrity sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,7 +1984,7 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/material@^5.8.5", "@mui/material@^5.8.6":
+"@mui/material@^5.8.5":
   version "5.8.6"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.8.6.tgz#4019fbf1b95d8ea9f397efaed835ac92a6d8f22d"
   integrity sha512-9fo5AiNHs+HY5ArMzsDMFrAmJSRw90y/qu81oDIszgK7Bfrm8GuI7Eb0mO6WADWPEyKOzOov/WZsm4G6jPEM4g==


### PR DESCRIPTION
As people will need to use `czifui` in their apps also (for more custom components), leave it as a peer dependency.

All the apps `package.json`s and peer dependencies on the `@czb-ui/core` package have been updated.

For the test-app, a a `czifui` button was added to make sure `czifui` is being imported correctly. Both apps now have at least one `czifui` component.

Also the README for `@czb-ui/core` has been updated to include all the packages needed.

