### PR TITLE
 Legacy Info Box component: Fix image over border and whole component overflowing

### DIFF
--- a/.changeset/early-jeans-think.md
+++ b/.changeset/early-jeans-think.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": patch
+---
+
+Fix legacy info box component overflowing over other elements in smaller breakpoints

--- a/.changeset/rotten-books-warn.md
+++ b/.changeset/rotten-books-warn.md
@@ -1,0 +1,6 @@
+---
+"storybook": patch
+"tina-cms-test-app": patch
+---
+
+Fix images going over border in legacy info box

--- a/.changeset/rotten-books-warn.md
+++ b/.changeset/rotten-books-warn.md
@@ -1,6 +1,6 @@
 ---
 "storybook": patch
-"tina-cms-test-app": patch
+"@czb-ui/tina-cms": patch
 ---
 
 Fix images going over border in legacy info box

--- a/apps/storybook/stories/LegacyInfoBox.stories.tsx
+++ b/apps/storybook/stories/LegacyInfoBox.stories.tsx
@@ -19,7 +19,8 @@ const Template = (args: any) => (
     {...args}
     image={
       <img
-        style={{ objectFit: "cover", height: 160, width: 300, zIndex: 0 }}
+        // Subtract 2 because of the border around the image
+        style={{ objectFit: "cover", height: 158, width: 298, zIndex: 0 }}
         src={args.image}
       />
     }

--- a/packages/core/src/LegacyInfoBox/LegacyInfoBox.tsx
+++ b/packages/core/src/LegacyInfoBox/LegacyInfoBox.tsx
@@ -83,7 +83,6 @@ export const LegacyInfoBox = ({
       gap={{ xs: "10px", sm: "30px" }}
       alignItems={{ xs: "flex-start", sm: "center" }}
       flexDirection={{ xs: "column", sm: "row" }}
-      height={160}
     >
       <Box border="1px solid" borderColor="divider" width={300} height={160}>
         {image}

--- a/packages/tina-cms/src/components/LegacyInfoBox/LegacyInfoBoxBlock.tsx
+++ b/packages/tina-cms/src/components/LegacyInfoBox/LegacyInfoBoxBlock.tsx
@@ -41,14 +41,14 @@ export const LegacyInfoBoxBlock = ({
         page={page}
         image={
           block.image ? (
-            <Box position="relative" height="100%">
-              <Image
-                objectFit="cover"
-                width={300}
-                height={160}
-                src={block.image}
-              />
-            </Box>
+            <Image
+              objectFit="cover"
+              // Subtract 2 because of the
+              // border around the image
+              width={298}
+              height={158}
+              src={block.image}
+            />
           ) : undefined
         }
         pagesComponent={block.outsideLink ? undefined : NextLinkComposed}


### PR DESCRIPTION
- fix image going over border on test apps/tina cms blocks
- fix legacy info box overflowing with other elements in smaller breakpoint