### PR TITLE
Add ID prop to Heading Separator component, use IDs on TinaCMS headings

### DIFF
--- a/.changeset/swift-birds-argue.md
+++ b/.changeset/swift-birds-argue.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/tina-cms": patch
+---
+
+Add IDs to text headings and heading separator blocks. This allows for links that automatically scroll to the given heading. Currently the IDs mirror the text the heading has.

--- a/.changeset/yellow-dots-sneeze.md
+++ b/.changeset/yellow-dots-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": patch
+---
+
+Add id prop to Heading Separator component

--- a/packages/core/src/HeadingSeparator/HeadingSeparator.tsx
+++ b/packages/core/src/HeadingSeparator/HeadingSeparator.tsx
@@ -2,11 +2,12 @@ import { Box, Typography } from "@mui/material";
 
 interface HeadingSeparatorProps {
   title?: string;
+  id?: string;
 }
 
-export const HeadingSeparator = ({ title }: HeadingSeparatorProps) => {
+export const HeadingSeparator = ({ title, id }: HeadingSeparatorProps) => {
   return (
-    <Box>
+    <Box id={id}>
       <Typography mb={2} variant="h1">
         {title}
       </Typography>

--- a/packages/tina-cms/src/components/HeadingSeparator/HeadingSeparatorBlock.tsx
+++ b/packages/tina-cms/src/components/HeadingSeparator/HeadingSeparatorBlock.tsx
@@ -12,7 +12,7 @@ interface HeadingSeparatorProps {
 export const HeadingSeparatorBlock = ({ block }: HeadingSeparatorProps) => {
   return (
     <Container sx={{ my: 5 }}>
-      <HeadingSeparator title={block.title} />
+      <HeadingSeparator title={block.title} id={block.title} />
     </Container>
   );
 };

--- a/packages/tina-cms/src/components/Text/TextBlock.tsx
+++ b/packages/tina-cms/src/components/Text/TextBlock.tsx
@@ -22,27 +22,57 @@ interface TextBlockProps {
 // TODO: Headings only supoort text with this implementation. They might include links and other stuff,
 // thats when you need to go through the content array
 const h1Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h1">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h1" id={text}>
+      {text}
+    </Typography>
+  );
 };
 
 const h2Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h2">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h2" id={text}>
+      {text}
+    </Typography>
+  );
 };
 
 const h3Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h3">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h3" id={text}>
+      {text}
+    </Typography>
+  );
 };
 
 const h4Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h4">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h4" id={text}>
+      {text}
+    </Typography>
+  );
 };
 
 const h5Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h5">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h5" id={text}>
+      {text}
+    </Typography>
+  );
 };
 
 const h6Component = ({ children }: HeadingProps) => {
-  return <Typography variant="h6">{children.props.content[0].text}</Typography>;
+  const text = children.props.content[0].text;
+  return (
+    <Typography variant="h6" id={text}>
+      {children.props.content[0].text}
+    </Typography>
+  );
 };
 
 const imgComponent = (props: ImageProps) => {


### PR DESCRIPTION
- Add ID prop to Heading Separator component
- Add IDs to text headings and heading separator blocks. This allows for links that automatically scroll to the given heading. Currently the IDs mirror the text the heading has.