### PR TITLE
Add explicit contrast text to primary color

### DIFF
--- a/.changeset/giant-pets-fail.md
+++ b/.changeset/giant-pets-fail.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": patch
+---
+
+Text is now white on primary button (add explicit contrastText to primary color palette)

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -71,6 +71,16 @@ appTheme.typography.styles.header = headingStyles;
 // only way I thought of fixing it for now...
 export const biohubTheme = createTheme({
   ...makeThemeOptions(appTheme),
+  palette: {
+    ...makeThemeOptions(appTheme).palette,
+    // temp way of getting contrastText to mui theme
+    // types are saying that this is wrong also...
+    // @ts-ignore
+    primary: {
+      ...makeThemeOptions(appTheme).palette?.primary,
+      contrastText: "white",
+    },
+  },
   components: {
     ...makeThemeOptions(appTheme).components,
     MuiContainer: {


### PR DESCRIPTION
Right now I don't think czifui has the option to pass `contrastText` through their `makeThemeOptions()` function. So for right now I just overwrote it in `createTheme()`