### PR TITLE
enable external links in the Navibar

### DIFF
--- a/.changeset/giant-brooms-bathe.md
+++ b/.changeset/giant-brooms-bathe.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": minor
+---
+
+Add external link feature to nav bar (https://github.com/czbiohub/czb-ui/pull/30)

--- a/packages/core/src/NavBar/DesktopPagesMenu.tsx
+++ b/packages/core/src/NavBar/DesktopPagesMenu.tsx
@@ -14,15 +14,30 @@ export const DesktopPagesMenu = ({
   return (
     <Box sx={{ mx: 5 }}>
       {pages.map((page, i) => (
-        <Link
-          color="inherit"
-          component={pagesComponent}
-          to={page.to}
-          sx={{ mx: 5 }}
-          key={i}
-        >
-          {page.title}
-        </Link>
+        <a>
+        {!page.externalLink && (
+                <Link
+                  color="inherit"
+                  component={pagesComponent}
+                  to={page.to}
+                  sx={{ mx: 5 }}
+                  key={i}
+                >
+                  {page.title}
+                </Link>
+        )}
+        {page.externalLink && (
+                <Link
+                  color="inherit"
+                  component={pagesComponent}
+                  href={page.to}
+                  sx={{ mx: 5 }}
+                  key={i}
+                >
+                  {page.title}
+                </Link>
+        )}
+        </a>
       ))}
     </Box>
   );

--- a/packages/core/src/NavBar/DesktopPagesMenu.tsx
+++ b/packages/core/src/NavBar/DesktopPagesMenu.tsx
@@ -14,30 +14,25 @@ export const DesktopPagesMenu = ({
   return (
     <Box sx={{ mx: 5 }}>
       {pages.map((page, i) => (
-        <a>
-        {!page.externalLink && (
-                <Link
-                  color="inherit"
-                  component={pagesComponent}
-                  to={page.to}
-                  sx={{ mx: 5 }}
-                  key={i}
-                >
-                  {page.title}
-                </Link>
-        )}
-        {page.externalLink && (
-                <Link
-                  color="inherit"
-                  component={pagesComponent}
-                  href={page.to}
-                  sx={{ mx: 5 }}
-                  key={i}
-                >
-                  {page.title}
-                </Link>
-        )}
-        </a>
+        <>
+          {!page.externalLink && (
+            <Link
+              color="inherit"
+              component={page?.to ? pagesComponent : undefined}
+              to={page?.to}
+              sx={{ mx: 5 }}
+              key={i}
+            >
+              {page?.title}
+            </Link>
+          )}
+          {/* If target="_blank" needs to be added also add rel="noopener" */}
+          {page.externalLink && (
+            <Link color="inherit" sx={{ mx: 5 }} key={i} href={page?.to}>
+              {page?.title}
+            </Link>
+          )}
+        </>
       ))}
     </Box>
   );

--- a/packages/core/src/NavBar/MobilePagesMenu.tsx
+++ b/packages/core/src/NavBar/MobilePagesMenu.tsx
@@ -31,16 +31,32 @@ export const MobilePagesMenu = ({
           }}
         >
           {pages.map((page, i) => (
-            <Link
-              color="inherit"
-              component={pagesComponent}
-              to={page.to}
-              sx={{ mx: 5 }}
-              onClick={() => setOpen(false)}
-              key={i}
-            >
-              <ListItemButton>{page.title}</ListItemButton>
-            </Link>
+            <a>
+              {!page.externalLink && (
+                    <Link
+                      color="inherit"
+                      component={pagesComponent}
+                      to={page.to}
+                      sx={{ mx: 5 }}
+                      onClick={() => setOpen(false)}
+                      key={i}
+                    >
+                      <ListItemButton>{page.title}</ListItemButton>
+                    </Link>
+              )}
+              {page.externalLink && (
+                    <Link
+                      color="inherit"
+                      component={pagesComponent}
+                      href={page.to}
+                      sx={{ mx: 5 }}
+                      onClick={() => setOpen(false)}
+                      key={i}
+                    >
+                      <ListItemButton>{page.title}</ListItemButton>
+                    </Link>
+              )}
+            </a>
           ))}
         </Drawer>
       </Box>

--- a/packages/core/src/NavBar/MobilePagesMenu.tsx
+++ b/packages/core/src/NavBar/MobilePagesMenu.tsx
@@ -31,32 +31,32 @@ export const MobilePagesMenu = ({
           }}
         >
           {pages.map((page, i) => (
-            <a>
+            <>
               {!page.externalLink && (
-                    <Link
-                      color="inherit"
-                      component={pagesComponent}
-                      to={page.to}
-                      sx={{ mx: 5 }}
-                      onClick={() => setOpen(false)}
-                      key={i}
-                    >
-                      <ListItemButton>{page.title}</ListItemButton>
-                    </Link>
+                <Link
+                  color="inherit"
+                  component={page?.to ? pagesComponent : undefined}
+                  to={page?.to}
+                  sx={{ mx: 5 }}
+                  onClick={() => setOpen(false)}
+                  key={i}
+                >
+                  <ListItemButton>{page.title}</ListItemButton>
+                </Link>
               )}
+              {/* If target="_blank" needs to be added also add rel="noopener" */}
               {page.externalLink && (
-                    <Link
-                      color="inherit"
-                      component={pagesComponent}
-                      href={page.to}
-                      sx={{ mx: 5 }}
-                      onClick={() => setOpen(false)}
-                      key={i}
-                    >
-                      <ListItemButton>{page.title}</ListItemButton>
-                    </Link>
+                <Link
+                  color="inherit"
+                  sx={{ mx: 5 }}
+                  onClick={() => setOpen(false)}
+                  key={i}
+                  href={page?.to}
+                >
+                  <ListItemButton>{page.title}</ListItemButton>
+                </Link>
               )}
-            </a>
+            </>
           ))}
         </Drawer>
       </Box>


### PR DESCRIPTION
Added external link support to navibar.

I had to wrap \<Link\> inside \<a\> to have the "href" prop passed correctly (following Sam's adivce)