### PR TITLE
Fix NavBar long menu titles taking two lines

### DIFF
--- a/.changeset/fifty-tables-dream.md
+++ b/.changeset/fifty-tables-dream.md
@@ -1,0 +1,5 @@
+---
+"@czb-ui/core": patch
+---
+
+Fix NavBar long menu titles taking two lines

--- a/packages/core/src/NavBar/DesktopPagesMenu.tsx
+++ b/packages/core/src/NavBar/DesktopPagesMenu.tsx
@@ -15,7 +15,7 @@ export const DesktopPagesMenu = ({
     <Box sx={{ mx: 5 }}>
       <List sx={{ display: "flex", flexDirection: "row" }}>
         {pages.map((page, i) => (
-          <ListItem disableGutters key={i}>
+          <ListItem disableGutters key={i} sx={{ flexBasis: "content" }}>
             {!page.externalLink && (
               <Link
                 color="inherit"


### PR DESCRIPTION
Use `flexBasis` to allow for flexible widths of each menu item in the NavBar

Before:
<img width="751" alt="Screenshot 2023-05-07 at 1 48 38 PM" src="https://user-images.githubusercontent.com/56655579/236701928-b8285eb2-6cb3-4e8e-8943-f77eca98258e.png">

After:
<img width="748" alt="Screenshot 2023-05-07 at 1 48 43 PM" src="https://user-images.githubusercontent.com/56655579/236701930-94e9e06d-4aed-43e5-b1ba-facbdc613a85.png">
