### PR TITLE
Import Fontsource fonts correctly

### DIFF
--- a/.changeset/sour-lizards-buy.md
+++ b/.changeset/sour-lizards-buy.md
@@ -2,4 +2,12 @@
 "@czb-ui/core": minor
 ---
 
-Use Barlow font in buttons, **breaking change**: Please update the Barlow and Lato imports to import the whole CSS files
+Use Barlow font in buttons, **breaking change**: Please update the font imports:
+
+```js
+import "@fontsource/hanken-grotesk/400.css";
+import "@fontsource/hanken-grotesk/700.css";
+import "@fontsource/stix-two-text/600.css";
+import "@fontsource/lato/700.css";
+import "@fontsource/barlow/600.css";
+```

--- a/apps/czb-ui-storybook/.storybook/preview.tsx
+++ b/apps/czb-ui-storybook/.storybook/preview.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { ThemeProvider } from "@czb-ui/core/src";
 
-import "@fontsource/barlow";
-import "@fontsource/lato";
-import "@fontsource/hanken-grotesk";
-import "@fontsource/stix-two-text";
+import "@fontsource/hanken-grotesk/400.css";
+import "@fontsource/hanken-grotesk/700.css";
+import "@fontsource/stix-two-text/600.css";
+import "@fontsource/lato/700.css";
+import "@fontsource/barlow/600.css";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/apps/docs/pages/_app.js
+++ b/apps/docs/pages/_app.js
@@ -8,10 +8,11 @@ import Footer from "../components/Footer/Footer";
 import DocsMenu from "../components/DocsMenu/DocsMenu";
 import TogglesContext from "../utils/TogglesContext";
 
-import "@fontsource/barlow";
-import "@fontsource/lato";
-import "@fontsource/hanken-grotesk";
-import "@fontsource/stix-two-text";
+import "@fontsource/hanken-grotesk/400.css";
+import "@fontsource/hanken-grotesk/700.css";
+import "@fontsource/stix-two-text/600.css";
+import "@fontsource/lato/700.css";
+import "@fontsource/barlow/600.css";
 
 // Import Butler font
 import "../public/fonts/Butler.css";

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -46,6 +46,8 @@ appTheme.typography.styles.header.xl = newFontHeaderXl;
 const newFontHeaderL = {
   ...defaultAppTheme.typography.styles.header.l,
   fontFamily: "Lato",
+  fontWeight: 700, // There's only a 700 weight for Lato,
+  // not 600 which is what the defaultAppTheme uses
 };
 appTheme.typography.styles.header.l = newFontHeaderL;
 


### PR DESCRIPTION
Previously, only `400` weights were being imported.